### PR TITLE
gitignore (#71) run maven from npm (#81)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,15 @@
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <includeEmptyDirs>true</includeEmptyDirs>
+                    <resources>
+                        <resource>
+                            <directory>src/main/resources</directory>
+                            <excludes>
+                                <exclude>archetype-resources/react-app/node_modules/</exclude>
+                                <exclude>archetype-resources/angular-app/node_modules/</exclude>
+                            </excludes>
+                        </resource>
+                    </resources>
                 </configuration>
             </plugin>
 
@@ -268,7 +277,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>3.0.2</version>
+                    <configuration>
+                        <!-- Required so that .gitignore gets included in archetypes -->
+                        <!-- see https://issues.apache.org/jira/browse/MRESOURCES-190 -->
+                        <addDefaultExcludes>false</addDefaultExcludes>
+                    </configuration>
                 </plugin>
 
                 <!-- Maven Compiler Plugin -->

--- a/src/main/resources/archetype-resources/angular-app/package.json
+++ b/src/main/resources/archetype-resources/angular-app/package.json
@@ -11,7 +11,8 @@
     "test": "ng test --watch=false",
     "test:debug": "ng test --watch=true",
     "lint": "tslint ./src/**/*.ts -t verbose",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "deploy-local": "mvn -f ../pom.xml clean install -PautoInstallPackage"
   },
   "keywords": [],
   "author": "",

--- a/src/main/resources/archetype-resources/react-app/package.json
+++ b/src/main/resources/archetype-resources/react-app/package.json
@@ -8,7 +8,8 @@
     "sync": "aemsync -d -w ../ui.apps/src/main/content",
     "test": "react-scripts test --coverage",
     "test:debug": "react-scripts --inspect-brk test --coverage --no-cache --runInBand",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy-local": "mvn -f ../pom.xml clean install -PautoInstallPackage"
   },
   "proxy": "http://localhost:4502",
   "eslintConfig": {

--- a/src/test/resources/projects/angular/reference/angular-app/package.json
+++ b/src/test/resources/projects/angular/reference/angular-app/package.json
@@ -11,7 +11,8 @@
     "test": "ng test --watch=false",
     "test:debug": "ng test --watch=true",
     "lint": "tslint ./src/**/*.ts -t verbose",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "deploy-local": "mvn -f ../pom.xml clean install -PautoInstallPackage"
   },
   "keywords": [],
   "author": "",

--- a/src/test/resources/projects/react/reference/react-app/package.json
+++ b/src/test/resources/projects/react/reference/react-app/package.json
@@ -8,7 +8,8 @@
     "sync": "aemsync -d -w ../ui.apps/src/main/content",
     "test": "react-scripts test --coverage",
     "test:debug": "react-scripts --inspect-brk test --coverage --no-cache --runInBand",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy-local": "mvn -f ../pom.xml clean install -PautoInstallPackage"
   },
   "proxy": "http://localhost:4502",
   "eslintConfig": {


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-spa-project-archetype/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | Fixes #71 , Fixes #81  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          | No
| Minor: New Feature?      | Yes
| Major: Breaking Change?  | No
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  | maven-resources-plugin 2.7 -> 3.0.2
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->

This implements #71 - .gitignore files will now be created automatically.
Also implements #81 - Add a convenience script which executes maven from npm to deploy the react/angular package to a local AEM instance